### PR TITLE
[FIX] stock: customer/vendor location empty

### DIFF
--- a/addons/stock/data/stock_data.yml
+++ b/addons/stock/data/stock_data.yml
@@ -1,8 +1,6 @@
 -
   !python {model: res.partner, id: base.main_partner}: |
     main_warehouse = self.env['stock.warehouse'].browse(ref('warehouse0'))
-    self.write({'property_stock_customer':main_warehouse.lot_stock_id.id})    
-
 -
   !python {model: ir.model.data, id: False}: |
     main_warehouse = self.env['stock.warehouse'].browse(ref('warehouse0'))
@@ -30,4 +28,7 @@
     companies = self.search([('internal_transit_location_id', '=', False)])
     for company in companies:
         company.create_transit_location()
+        internal_transit = company.internal_transit_location_id.id
+        warehouses = self.env['stock.warehouse'].search([('partner_id', '=', company.partner_id.id)])
+        warehouses.mapped('partner_id').with_context(force_company=company.id).write({'property_stock_customer': internal_transit, 'property_stock_supplier': internal_transit})
 

--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -32,8 +32,8 @@ class Company(models.Model):
     def create(self, vals):
         company = super(Company, self).create(vals)
 
-        # multi-company rules prevents creating warehouse and sub-locations
+        company.create_transit_location()
+        # mutli-company rules prevents creating warehouse and sub-locations
         self.env['stock.warehouse'].check_access_rights('create')
         self.env['stock.warehouse'].sudo().create({'name': company.name, 'code': company.name[:5], 'company_id': company.id, 'partner_id': company.partner_id.id})
-        company.create_transit_location()
         return company

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -178,9 +178,10 @@ class Warehouse(models.Model):
         ResCompany = self.env['res.company']
         if company_id:
             transit_loc = ResCompany.browse(company_id).internal_transit_location_id.id
+            self.env['res.partner'].browse(partner_id).with_context(force_company=company_id).write({'property_stock_customer': transit_loc, 'property_stock_supplier': transit_loc})
         else:
             transit_loc = ResCompany._company_default_get('stock.warehouse').internal_transit_location_id.id
-        self.env['res.partner'].browse(partner_id).write({'property_stock_customer': transit_loc, 'property_stock_supplier': transit_loc})
+            self.env['res.partner'].browse(partner_id).write({'property_stock_customer': transit_loc, 'property_stock_supplier': transit_loc})
 
     def create_sequences_and_picking_types(self):
         IrSequenceSudo = self.env['ir.sequence'].sudo()


### PR DESCRIPTION
When creating a new company, the fields customer/vendor location
were empty.

Now, these fields are set with the internal transit location for the company
of the partner and set with Partners Locations/Customers and Partners Locations/Vendors
for the other companies.

opw:1845753

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
